### PR TITLE
Add Testing phase verification gate for Spec acceptance criteria

### DIFF
--- a/skills/swain-design/SKILL.md
+++ b/skills/swain-design/SKILL.md
@@ -67,6 +67,7 @@ Phases listed in the artifact definition files are available waypoints, not mand
 2. **Move the artifact** to the new phase subdirectory using `git mv` (e.g., `git mv docs/epic/Proposed/(EPIC-001)-Foo/ docs/epic/Active/(EPIC-001)-Foo/`). Every artifact type uses phase subdirectories — see the artifact's definition file for the exact directory names.
 3. Update the artifact's status field in frontmatter to match the new phase.
 4. **ADR compliance check** — for transitions to active phases (Active, Approved, Ready, Implemented, Adopted), run `scripts/adr-check.sh <artifact-path>`. Review any findings with the user before committing.
+4a. **Verification gate (SPEC only)** — for `Testing → Implemented` transitions, run `scripts/spec-verify.sh <artifact-path>`. The script checks that every acceptance criterion has documented evidence in the Verification table. Address gaps before proceeding. See `spec-definition.md § Testing phase` for details.
 5. Commit the transition change (move + status update).
 6. Append a row to the artifact's lifecycle table with the commit hash from step 5.
 7. Commit the hash stamp as a **separate commit** — never amend. Two distinct commits keeps the stamped hash reachable in git history and avoids interactive-rebase pitfalls.
@@ -76,7 +77,7 @@ Phases listed in the artifact definition files are available waypoints, not mand
 ### Completion rules
 
 - An Epic is "Complete" only when all child Agent Specs are "Implemented" and success criteria are met.
-- An Agent Spec is "Implemented" only when its implementation plan is closed (or all tasks are done in fallback mode).
+- An Agent Spec is "Implemented" only when its implementation plan is closed (or all tasks are done in fallback mode) **and** its Verification table confirms all acceptance criteria pass (enforced by `spec-verify.sh`).
 - An ADR is "Superseded" only when the superseding ADR is "Adopted" and links back.
 
 ## Execution tracking handoff
@@ -181,6 +182,7 @@ Three scripts support artifact workflows. Each is in `scripts/` relative to this
 | `specwatch.sh` | `scan` | Stale reference detection + artifact/bd sync check. Run after every artifact operation. If `.agents/specwatch.log` reports issues, fix before committing. For log format and subcommands, read [references/specwatch-guide.md](references/specwatch-guide.md). |
 | `specgraph.sh` | `overview` | Dependency graph — hierarchy tree with status indicators. For subcommands and output interpretation, read [references/specgraph-guide.md](references/specgraph-guide.md). |
 | `adr-check.sh` | `<artifact-path>` | ADR compliance — checks artifact against Adopted ADRs for relevance, dead refs to Retired/Superseded ADRs, and staleness. Exit 0 = clean, exit 1 = findings. If findings, read [references/adr-check-guide.md](references/adr-check-guide.md) for interpretation and content-level review procedure. |
+| `spec-verify.sh` | `<artifact-path>` | Verification gate — checks a Spec's Verification table against its Acceptance Criteria. Gates `Testing → Implemented`. Exit 0 = all criteria covered, exit 1 = gaps or failures found, exit 2 = usage error. |
 
 ## Lifecycle table format
 

--- a/skills/swain-design/references/implementation-plans.md
+++ b/skills/swain-design/references/implementation-plans.md
@@ -23,7 +23,11 @@ When superpowers is present, the brainstorming step should produce a TDD-structu
 
 ## Closing the loop
 
-- Progress lives in the execution backend, not the spec doc. Transition the spec to "Implemented" once the plan completes.
+- Progress lives in the execution backend, not the spec doc.
+- When all plan tasks are complete, transition the Spec to **Testing** (not directly to Implemented). The Testing phase is where acceptance criteria are verified against evidence — see `spec-definition.md § Testing phase`.
+- In the Testing phase, populate the Spec's **Verification** table: map each acceptance criterion to its evidence (test name, file, demo) and record Pass/Fail/Skip.
+- Run `scripts/spec-verify.sh <artifact-path>` before transitioning from Testing → Implemented. The script confirms every criterion has evidence.
+- Only after verification passes, transition the Spec to **Implemented**.
 - Note cross-spec tasks in each affected artifact's lifecycle entry (e.g., "Implemented — shared serializer also covers SPEC-007").
 - If execution reveals the spec is unworkable, the swain-do skill's escalation protocol flows control back to the swain-design skill for spec updates before re-planning.
 

--- a/skills/swain-design/references/spec-definition.md
+++ b/skills/swain-design/references/spec-definition.md
@@ -28,3 +28,35 @@ Follow **spec-driven development** principles: an Agent Spec is a behavior contr
   - Supporting docs live alongside it in the same folder.
 - Should be scoped to something a team (or agent) can ship and validate independently.
 - **Tracking requirement:** All Specs carry `swain-do: required` in frontmatter. When a Spec comes up for implementation, invoke the swain-do skill to create a tracked plan before writing code (see SKILL.md § Execution tracking handoff).
+
+## Testing phase
+
+The `Testing` phase is the acceptance-verification gate between implementation and completion. A Spec enters `Testing` when its swain-do implementation plan is complete (all tasks done). It exits `Testing` only when every acceptance criterion has documented evidence.
+
+### Entering Testing
+
+When all swain-do tasks for a Spec are complete, transition the Spec from `Approved` to `Testing`. Do **not** skip directly to `Implemented`.
+
+### Verification table
+
+On entry to `Testing`, populate the Spec's **Verification** section. For each acceptance criterion:
+
+1. **Criterion** — copy or paraphrase the Given/When/Then scenario from the Acceptance Criteria section.
+2. **Evidence** — the test name, file path, manual check, or demo scenario that proves the criterion is satisfied. Reference specific test functions or files (e.g., `test_widget_export in tests/test_widget.py`).
+3. **Result** — one of: `Pass`, `Fail`, or `Skip (reason)`.
+
+Every criterion must have a non-empty Evidence and Result cell before the Spec can transition to `Implemented`.
+
+### Verification gate
+
+Before transitioning from `Testing → Implemented`, run `scripts/spec-verify.sh <artifact-path>`. The script checks that every acceptance criterion has corresponding evidence. Exit 0 = all criteria covered. Exit 1 = gaps found. Address gaps before proceeding.
+
+### Supporting docs
+
+For complex Specs with extensive test evidence (10+ criteria, multi-environment matrices), place detailed results in a `verification-report.md` alongside the Spec in its folder. The Verification table in the Spec should summarize; the report holds the detail.
+
+```
+docs/spec/Testing/(SPEC-003)-Widget-Factory/
+  (SPEC-003)-Widget-Factory.md       ← the spec (with summary Verification table)
+  verification-report.md             ← detailed evidence (optional)
+```

--- a/skills/swain-design/references/spec-template.md.template
+++ b/skills/swain-design/references/spec-template.md.template
@@ -40,6 +40,18 @@ swain-do: required
 
 {{ acceptance_criteria | default("Given/When/Then scenarios — concise and verifiable.") }}
 
+## Verification
+
+<!-- Populated when entering Testing phase. Maps each acceptance criterion
+     to its evidence: test name, manual check, or demo scenario.
+     Leave empty until Testing. -->
+
+| Criterion | Evidence | Result |
+|-----------|----------|--------|
+{%- for criterion in verification | default([]) %}
+| {{ criterion.name }} | {{ criterion.evidence }} | {{ criterion.result }} |
+{%- endfor %}
+
 ## Scope & Constraints
 
 {{ scope_constraints | default("Boundaries, non-goals, and token-budget awareness.") }}

--- a/skills/swain-design/scripts/spec-verify.sh
+++ b/skills/swain-design/scripts/spec-verify.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# spec-verify.sh — Verify a Spec's acceptance criteria have documented evidence.
+# Gates the Testing → Implemented transition by checking the Verification table.
+#
+# Output goes to stdout in a structured format. Exit 0 = all criteria covered,
+# exit 1 = gaps found, exit 2 = usage error.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: spec-verify.sh <artifact-path>
+
+Checks a Spec artifact's Verification table against its Acceptance Criteria:
+  1. Every acceptance criterion has a row in the Verification table
+  2. Every row has non-empty Evidence and Result columns
+  3. No rows have a "Fail" result
+
+Output format:
+  MISSING_EVIDENCE <criterion-summary>
+    action: add Evidence and Result for this criterion
+
+  FAIL <criterion-summary>
+    evidence: <what was tested>
+    action: fix failing criterion before transitioning to Implemented
+
+  EMPTY_TABLE
+    action: populate Verification table before transitioning to Implemented
+
+Summary line:
+  OK SPEC-NNN: N/N criteria verified
+  GAPS SPEC-NNN: N/M criteria verified, K gaps
+
+Exit codes:
+  0  All criteria verified (no Fail results, no gaps)
+  1  Gaps or failures found
+  2  Usage error
+USAGE
+}
+
+if [ $# -lt 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  usage
+  exit 2
+fi
+
+ARTIFACT_PATH="$1"
+
+if [ ! -f "$ARTIFACT_PATH" ]; then
+  echo "Error: artifact not found: $ARTIFACT_PATH" >&2
+  exit 2
+fi
+
+python3 - "$ARTIFACT_PATH" <<'PYEOF'
+import re, sys
+
+artifact_path = sys.argv[1]
+
+with open(artifact_path) as f:
+    content = f.read()
+
+# --- Extract artifact ID from frontmatter ---
+
+art_id = ""
+fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n', content, re.DOTALL)
+if fm_match:
+    for line in fm_match.group(1).split('\n'):
+        m = re.match(r'^artifact:\s*(SPEC-\d+)', line)
+        if m:
+            art_id = m.group(1)
+            break
+
+if not art_id:
+    print("Error: not a SPEC artifact or missing artifact ID in frontmatter", file=sys.stderr)
+    sys.exit(2)
+
+# --- Check artifact is in Testing phase ---
+
+status = ""
+if fm_match:
+    for line in fm_match.group(1).split('\n'):
+        m = re.match(r'^status:\s*(.+)', line)
+        if m:
+            status = m.group(1).strip()
+            break
+
+if status and status != "Testing":
+    print(f"Warning: {art_id} is in phase '{status}', not 'Testing'", file=sys.stderr)
+
+# --- Extract Acceptance Criteria section ---
+
+ac_match = re.search(
+    r'##\s*Acceptance Criteria\s*\n(.*?)(?=\n##\s|\Z)',
+    content, re.DOTALL
+)
+
+if not ac_match:
+    print(f"Error: {art_id} has no Acceptance Criteria section", file=sys.stderr)
+    sys.exit(2)
+
+ac_text = ac_match.group(1).strip()
+
+# Count criteria: lines starting with - or * or numbered, or Given/When/Then blocks
+criteria = []
+for line in ac_text.split('\n'):
+    line = line.strip()
+    # Skip empty lines and table formatting
+    if not line or line.startswith('|') or line.startswith('<!--'):
+        continue
+    # Bullet points, numbered items, or Given/When/Then
+    if re.match(r'^[-*]\s+', line) or re.match(r'^\d+[.)]\s+', line) or re.match(r'^(Given|When|Then|And|But)\s+', line, re.IGNORECASE):
+        criteria.append(line.lstrip('-*0123456789.) \t'))
+
+if not criteria:
+    print(f"Warning: {art_id} has no parseable acceptance criteria", file=sys.stderr)
+    # Don't fail — the agent should review manually
+    print(f"OK {art_id}: no parseable criteria to verify (manual review recommended)")
+    sys.exit(0)
+
+# --- Extract Verification table ---
+
+ver_match = re.search(
+    r'##\s*Verification\s*\n(.*?)(?=\n##\s|\Z)',
+    content, re.DOTALL
+)
+
+if not ver_match:
+    print(f"EMPTY_TABLE")
+    print(f"  action: add Verification section and populate before transitioning to Implemented")
+    print()
+    print(f"GAPS {art_id}: 0/{len(criteria)} criteria verified, {len(criteria)} gaps")
+    sys.exit(1)
+
+ver_text = ver_match.group(1).strip()
+
+# Parse table rows (skip header and separator)
+ver_rows = []
+table_lines = [l for l in ver_text.split('\n') if l.strip().startswith('|')]
+
+# Need at least header + separator + 1 data row
+if len(table_lines) < 3:
+    print(f"EMPTY_TABLE")
+    print(f"  action: populate Verification table before transitioning to Implemented")
+    print()
+    print(f"GAPS {art_id}: 0/{len(criteria)} criteria verified, {len(criteria)} gaps")
+    sys.exit(1)
+
+# Parse data rows (skip header row and separator row)
+for row in table_lines[2:]:
+    cells = [c.strip() for c in row.split('|')]
+    # Remove empty first/last from leading/trailing pipes
+    cells = [c for c in cells if c or c == '']
+    if len(cells) >= 3:
+        ver_rows.append({
+            'criterion': cells[0].strip(),
+            'evidence': cells[1].strip() if len(cells) > 1 else '',
+            'result': cells[2].strip() if len(cells) > 2 else '',
+        })
+
+if not ver_rows:
+    print(f"EMPTY_TABLE")
+    print(f"  action: populate Verification table before transitioning to Implemented")
+    print()
+    print(f"GAPS {art_id}: 0/{len(criteria)} criteria verified, {len(criteria)} gaps")
+    sys.exit(1)
+
+# --- Check for gaps ---
+
+findings = []
+verified = 0
+
+for row in ver_rows:
+    if not row['evidence'] or not row['result']:
+        findings.append({
+            'type': 'MISSING_EVIDENCE',
+            'criterion': row['criterion'],
+        })
+    elif row['result'].lower().startswith('fail'):
+        findings.append({
+            'type': 'FAIL',
+            'criterion': row['criterion'],
+            'evidence': row['evidence'],
+        })
+    elif row['result'].lower().startswith('pass'):
+        verified += 1
+    elif row['result'].lower().startswith('skip'):
+        verified += 1  # Skip with reason counts as addressed
+
+total = len(ver_rows)
+
+# Also check: fewer verification rows than acceptance criteria
+if total < len(criteria):
+    findings.append({
+        'type': 'COUNT_MISMATCH',
+        'ver_count': total,
+        'ac_count': len(criteria),
+    })
+
+# --- Output ---
+
+if not findings:
+    print(f"OK {art_id}: {verified}/{total} criteria verified")
+    sys.exit(0)
+
+for f in findings:
+    if f['type'] == 'MISSING_EVIDENCE':
+        print(f"MISSING_EVIDENCE {f['criterion']}")
+        print(f"  action: add Evidence and Result for this criterion")
+        print()
+    elif f['type'] == 'FAIL':
+        print(f"FAIL {f['criterion']}")
+        print(f"  evidence: {f['evidence']}")
+        print(f"  action: fix failing criterion before transitioning to Implemented")
+        print()
+    elif f['type'] == 'COUNT_MISMATCH':
+        print(f"COUNT_MISMATCH verification rows ({f['ver_count']}) < acceptance criteria ({f['ac_count']})")
+        print(f"  action: ensure every acceptance criterion has a Verification row")
+        print()
+
+gaps = len(findings)
+print(f"GAPS {art_id}: {verified}/{total} criteria verified, {gaps} issue(s)")
+sys.exit(1)
+PYEOF


### PR DESCRIPTION
## Summary

Introduces a formal **Testing phase** as an acceptance-verification gate between implementation and completion of Specs. This ensures every acceptance criterion has documented evidence before a Spec can transition to Implemented.

## Key Changes

- **New verification script** (`scripts/spec-verify.sh`): Automated gate that validates a Spec's Verification table against its Acceptance Criteria. Checks that:
  - Every acceptance criterion has a corresponding verification row
  - Each row has non-empty Evidence and Result columns
  - No rows have "Fail" results
  - Exits 0 if all criteria verified, 1 if gaps found, 2 on usage error

- **Updated Spec lifecycle** (`spec-definition.md`): Documented the Testing phase as a mandatory waypoint:
  - Specs enter Testing when all swain-do implementation tasks complete
  - Specs exit Testing only when verification passes
  - Verification table maps each criterion to evidence (test name, file path, manual check, or demo scenario)
  - Results recorded as Pass/Fail/Skip with optional reason

- **Updated Spec template** (`spec-template.md.template`): Added empty Verification table section with column headers (Criterion, Evidence, Result) to be populated during Testing phase

- **Updated implementation guidance** (`implementation-plans.md`): Clarified the handoff flow:
  - Complete swain-do plan → transition to Testing (not directly to Implemented)
  - Populate Verification table in Testing phase
  - Run `spec-verify.sh` before Testing → Implemented transition
  - Only proceed to Implemented after verification passes

- **Updated skill documentation** (`SKILL.md`): Added verification check as a required step for transitions to active phases

## Implementation Details

The verification script parses Markdown artifacts to:
- Extract artifact ID and status from frontmatter
- Parse Acceptance Criteria section (supports bullet points, numbered lists, and Given/When/Then format)
- Parse Verification table (markdown table format)
- Report gaps with actionable guidance (MISSING_EVIDENCE, FAIL, EMPTY_TABLE, COUNT_MISMATCH)
- Support optional detailed verification reports in separate files for complex Specs

This creates a clear, auditable record of which tests/checks validate each acceptance criterion before a Spec is marked complete.

https://claude.ai/code/session_01HU9d8XqHZhPKKsPUNWWav8